### PR TITLE
feat: default to YomiToku OCR engine

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,8 @@ import {
   getResults,
   getStatus,
   retryToken,
-  uploadFiles
+  uploadFiles,
+  OcrBackend
 } from './api';
 
 const pageSize = 10;
@@ -20,7 +21,7 @@ const pageSize = 10;
 const App: React.FC = () => {
   const [dbFile, setDbFile] = useState<File | null>(null);
   const [pdfFiles, setPdfFiles] = useState<File[]>([]);
-  const [ocrBackend, setOcrBackend] = useState('rapidocr');
+  const [ocrBackend, setOcrBackend] = useState<OcrBackend>('yomitoku');
   const [taskId, setTaskId] = useState<string | null>(null);
   const [status, setStatus] = useState<StatusResponse | null>(null);
   const [progress, setProgress] = useState(0);
@@ -135,7 +136,7 @@ const App: React.FC = () => {
           <span style={{ fontSize: 14, color: '#4B5563' }}>OCRエンジン</span>
           <select
             value={ocrBackend}
-            onChange={(e) => setOcrBackend(e.target.value)}
+            onChange={(e) => setOcrBackend(e.target.value as OcrBackend)}
             style={{
               padding: '8px 12px',
               borderRadius: 12,
@@ -144,6 +145,7 @@ const App: React.FC = () => {
               backgroundColor: '#F8FAFC'
             }}
           >
+            <option value="yomitoku">YomiToku (デフォルト利用)</option>
             <option value="rapidocr">RapidOCR</option>
             <option value="paddleocr">PaddleOCR</option>
           </select>
@@ -272,6 +274,7 @@ const App: React.FC = () => {
               total={filteredFailures.length}
               onPageChange={setFailurePage}
               onRetry={handleRetry}
+              backendUsed={status?.backend_used}
             />
           )}
         </section>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,6 +2,8 @@ export interface UploadResponse {
   task_id: string;
 }
 
+export type OcrBackend = 'yomitoku' | 'rapidocr' | 'paddleocr';
+
 export interface StatusResponse {
   progress: number;
   pages: number;
@@ -11,6 +13,7 @@ export interface StatusResponse {
     hit_spec: number;
     fail: number;
   };
+  backend_used?: string;
 }
 
 export interface ResultItem {
@@ -35,7 +38,7 @@ export interface RetryResponse {
 export const uploadFiles = async (
   dbFile: File,
   pdfFiles: File[],
-  ocrBackend: string
+  ocrBackend: OcrBackend = 'yomitoku'
 ): Promise<UploadResponse> => {
   const formData = new FormData();
   formData.append('db_csv', dbFile);

--- a/frontend/src/components/FailuresTable.tsx
+++ b/frontend/src/components/FailuresTable.tsx
@@ -8,6 +8,7 @@ interface Props {
   total: number;
   onPageChange: (page: number) => void;
   onRetry: (token: string) => void;
+  backendUsed?: string;
 }
 
 const headerStyle: React.CSSProperties = {
@@ -24,11 +25,28 @@ const cellStyle: React.CSSProperties = {
   borderBottom: '1px solid #F3F4F6'
 };
 
-const FailuresTable: React.FC<Props> = ({ data, page, pageSize, total, onPageChange, onRetry }) => {
+const noticeStyle: React.CSSProperties = {
+  backgroundColor: '#FEE2E2',
+  color: '#B91C1C',
+  padding: '12px 16px',
+  fontSize: 13,
+  fontWeight: 500,
+  borderBottom: '1px solid #FCA5A5'
+};
+
+const FailuresTable: React.FC<Props> = ({ data, page, pageSize, total, onPageChange, onRetry, backendUsed }) => {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const trimmedBackend = backendUsed?.trim();
+  const showFallbackNotice =
+    !!trimmedBackend && trimmedBackend.toLowerCase() !== 'yomitoku';
 
   return (
     <div style={{ backgroundColor: '#FFFFFF', borderRadius: 16, boxShadow: '0 2px 12px rgba(0,0,0,0.08)', overflow: 'hidden' }}>
+      {showFallbackNotice && (
+        <div style={noticeStyle}>
+          ※ YomiToku が利用できなかったため {trimmedBackend} に切り替えました。
+        </div>
+      )}
       <table style={{ width: '100%', borderCollapse: 'separate', borderSpacing: 0 }}>
         <thead style={{ backgroundColor: '#FEE2E2' }}>
           <tr>

--- a/frontend/src/components/StatsCards.tsx
+++ b/frontend/src/components/StatsCards.tsx
@@ -12,6 +12,7 @@ interface Props {
     hit_spec: number;
     fail: number;
   };
+  backendUsed?: string;
 }
 
 const cardStyle: React.CSSProperties = {
@@ -34,7 +35,13 @@ const valueStyle: React.CSSProperties = {
   color: '#1D4ED8'
 };
 
-const StatsCards: React.FC<Props> = ({ totals }) => {
+const footerStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: '#6B7280',
+  marginTop: 8
+};
+
+const StatsCards: React.FC<Props> = ({ totals, backendUsed }) => {
   const stats: StatItem[] = [
     { title: '抽出トークン数', value: totals.tokens },
     { title: '品番一致', value: totals.hit_hinban },
@@ -50,6 +57,7 @@ const StatsCards: React.FC<Props> = ({ totals }) => {
           <div style={valueStyle}>{stat.value}</div>
         </div>
       ))}
+      <div style={footerStyle}>使用エンジン：{backendUsed ?? '—'}</div>
     </div>
   );
 };

--- a/frontend/src/components/UploadPanel.tsx
+++ b/frontend/src/components/UploadPanel.tsx
@@ -1,18 +1,18 @@
 import React, { useCallback } from 'react';
 import ProgressBar from './ProgressBar';
 import StatsCards from './StatsCards';
-import { StatusResponse } from '../api';
+import { OcrBackend, StatusResponse } from '../api';
 
 interface Props {
   dbFile: File | null;
   pdfFiles: File[];
-  ocrBackend: string;
+  ocrBackend: OcrBackend;
   status: StatusResponse | null;
   progress: number;
   isProcessing: boolean;
   onDbSelect: (file: File) => void;
   onPdfSelect: (files: File[]) => void;
-  onBackendChange: (backend: string) => void;
+  onBackendChange: (backend: OcrBackend) => void;
   onStart: () => void;
   error: string | null;
 }
@@ -125,7 +125,7 @@ const UploadPanel: React.FC<Props> = ({
         <div style={sectionTitle}>OCRエンジン</div>
         <select
           value={ocrBackend}
-          onChange={(e) => onBackendChange(e.target.value)}
+          onChange={(e) => onBackendChange(e.target.value as OcrBackend)}
           style={{
             width: '100%',
             padding: '10px 12px',
@@ -135,7 +135,8 @@ const UploadPanel: React.FC<Props> = ({
             marginTop: 10
           }}
         >
-          <option value="rapidocr">RapidOCR (推奨)</option>
+          <option value="yomitoku">YomiToku (デフォルト利用)</option>
+          <option value="rapidocr">RapidOCR</option>
           <option value="paddleocr">PaddleOCR</option>
         </select>
       </div>
@@ -172,7 +173,10 @@ const UploadPanel: React.FC<Props> = ({
 
       <div>
         <div style={sectionTitle}>統計サマリー</div>
-        <StatsCards totals={status?.totals || { tokens: 0, hit_hinban: 0, hit_spec: 0, fail: 0 }} />
+        <StatsCards
+          totals={status?.totals || { tokens: 0, hit_hinban: 0, hit_spec: 0, fail: 0 }}
+          backendUsed={status?.backend_used}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- set YomiToku as the default OCR engine throughout the upload experience
- include the selected OCR backend in upload requests and surface backend_used in the UI
- extend status typing and UI messaging to show fallback engines when YomiToku is unavailable

## Testing
- npm install *(fails in sandbox: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e61b17137483309edaf4cf713ad957