### PR TITLE
Align status model typing and add integration smoke tests

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
-
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -12,7 +11,7 @@ class UploadResponse(BaseModel):
 class StatusResponse(BaseModel):
     progress: int
     pages: int
-    totals: dict
+    totals: Dict[str, int]
     backend_used: Optional[str] = None
 
 

--- a/scripts/fixtures/master.csv
+++ b/scripts/fixtures/master.csv
@@ -1,0 +1,3 @@
+hinban,spec,zaiko
+ABC123,アルミパイプ,100
+XYZ789,ステンレスボルト,42

--- a/scripts/fixtures/sample.pdf
+++ b/scripts/fixtures/sample.pdf
@@ -1,0 +1,38 @@
+%PDF-1.3
+%߬
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Count 1/Kids[3 0 R]>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>
+endobj
+4 0 obj
+<</Length 56>>
+stream
+BT
+
+/F T 24 Tf
+(100 600) Td
+(Hello World) Tj
+ET
+endstream
+endobj
+5 0 obj
+<</Type/Font/Subtype/Type1/Name/F1/BaseFont/Helvetica>>
+endobj
+xref
+0 6
+000000000 65535 f 
+000000010 00000 n 
+000000061 00000 n 
+000000122 00000 n 
+000000217 00000 n 
+000000319 00000 n 
+trailer
+<</Root 1 0 R/Size 6>>
+startxref
+421
+%%EOF

--- a/scripts/smoke_test.http
+++ b/scripts/smoke_test.http
@@ -1,0 +1,47 @@
+@base = http://127.0.0.1:8000
+
+### Upload sample job
+POST {{base}}/api/upload
+Content-Type: multipart/form-data; boundary=Boundary123
+
+--Boundary123
+Content-Disposition: form-data; name="db_csv"; filename="master.csv"
+Content-Type: text/csv
+
+{{file scripts/fixtures/master.csv}}
+--Boundary123
+Content-Disposition: form-data; name="pdfs"; filename="sample.pdf"
+Content-Type: application/pdf
+
+{{file scripts/fixtures/sample.pdf}}
+--Boundary123
+Content-Disposition: form-data; name="ocr_backend"
+
+rapidocr
+--Boundary123--
+
+> {% client.global.set('task_id', response.body.task_id); %}
+
+### Poll status using saved task_id
+GET {{base}}/api/status/{{task_id}}
+
+### Fetch results
+GET {{base}}/api/results/{{task_id}}
+
+### Fetch failures
+GET {{base}}/api/failures/{{task_id}}
+
+### Retry a token
+POST {{base}}/api/retry
+Content-Type: application/json
+
+{
+  "task_id": "{{task_id}}",
+  "token": "ABC123"
+}
+
+### Download results CSV
+GET {{base}}/api/download/{{task_id}}?type=results
+
+### Download failures CSV
+GET {{base}}/api/download/{{task_id}}?type=failures

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_BASE=${API_BASE:-http://127.0.0.1:8000}
+FRONTEND_BASE=${FRONTEND_BASE:-http://127.0.0.1:5173}
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TMP_DIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cp "$SCRIPT_DIR/fixtures/master.csv" "$TMP_DIR/db.csv"
+cp "$SCRIPT_DIR/fixtures/sample.pdf" "$TMP_DIR/sample.pdf"
+
+echo "[1/6] Uploading sample job to $API_BASE/api/upload"
+UPLOAD_RESPONSE=$(curl -sS -f \
+  -F "db_csv=@$TMP_DIR/db.csv" \
+  -F "pdfs=@$TMP_DIR/sample.pdf" \
+  -F "ocr_backend=yomitoku" \
+  "$API_BASE/api/upload")
+
+task_id=$(python - <<'PY'
+import json, os
+payload = json.loads(os.environ['UPLOAD_RESPONSE'])
+print(payload['task_id'])
+PY
+)
+
+echo "    → task_id=$task_id"
+
+echo "[2/6] Polling status until completion"
+for attempt in {1..30}; do
+  STATUS_JSON=$(curl -sS "$API_BASE/api/status/$task_id") || true
+  progress=$(python - <<'PY'
+import json, os
+status = json.loads(os.environ.get('STATUS_JSON', '{}'))
+print(status.get('progress', 0))
+PY
+)
+  printf '    attempt %02d: progress=%s\n' "$attempt" "$progress"
+  if [[ "$progress" =~ ^[0-9]+$ ]] && [ "$progress" -ge 100 ]; then
+    break
+  fi
+  sleep 1
+  if [ "$attempt" -eq 30 ]; then
+    echo "Status polling timed out" >&2
+    exit 1
+  fi
+done
+
+echo "[3/6] Fetching results summary"
+RESULTS_JSON=$(curl -sS "$API_BASE/api/results/$task_id")
+FAILURES_JSON=$(curl -sS "$API_BASE/api/failures/$task_id")
+
+echo "    results count: $(python - <<'PY'
+import json, os
+print(len(json.loads(os.environ['RESULTS_JSON'])))
+PY
+)"
+echo "    failures count: $(python - <<'PY'
+import json, os
+print(len(json.loads(os.environ['FAILURES_JSON'])))
+PY
+)"
+
+echo "[4/6] Exercising retry endpoint"
+python - "$API_BASE" "$task_id" <<'PY'
+import json
+import os
+import sys
+import urllib.request
+
+base = sys.argv[1]
+task_id = sys.argv[2]
+req = urllib.request.Request(
+    f"{base}/api/retry",
+    data=json.dumps({"task_id": task_id, "token": "ABC123"}).encode(),
+    headers={"Content-Type": "application/json"},
+)
+with urllib.request.urlopen(req) as resp:
+    payload = json.loads(resp.read().decode())
+print("    retry candidates:", payload.get("candidates"))
+PY
+
+echo "[5/6] Downloading CSV exports"
+curl -sS -o "$TMP_DIR/results.csv" "$API_BASE/api/download/$task_id?type=results"
+curl -sS -o "$TMP_DIR/failures.csv" "$API_BASE/api/download/$task_id?type=failures"
+ls -lh "$TMP_DIR"/results.csv "$TMP_DIR"/failures.csv
+
+echo "[6/6] Optional: open frontend at $FRONTEND_BASE in a browser to trigger manual smoke test."


### PR DESCRIPTION
## Summary
- fix the backend status model typing so Optional and Dict annotations resolve correctly at runtime
- add reusable smoke test script, HTTP collection, and fixtures to exercise the upload/status/results workflow end-to-end

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e61d30f7c88330a7a4827e75b11bd5